### PR TITLE
Add a travis file for quicker testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+---
+
+language: node_js
+
+node_js:
+  - lts/*
+
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-4.9-dev
+
+cache:
+  directories:
+    - /tmp/liftoff
+
+matrix:
+  include:
+    - env: DIST=loki
+    - env: DIST=juno
+
+before_install:
+  - docker pull ubuntu:16.04
+
+install:
+  - npm install @elementaryos/houston
+
+script:
+  - houston ci
+    --name-appstream com.github.arshubham.srtnr.desktop
+    --name-domain com.github.arshubham.srtnr
+    --name-human srtnr
+    --distribution $DIST


### PR DESCRIPTION
Once travis is enabled on the repo, you can see the houston build output without having to make a new release every change. Should help with debugging.